### PR TITLE
Support to find multiple locale in 1 query

### DIFF
--- a/lib/hstore_translate/version.rb
+++ b/lib/hstore_translate/version.rb
@@ -1,3 +1,3 @@
 module HstoreTranslate
-  VERSION = "1.0.0.1"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Before: The query is one per locale, so in case we want to find something in multiple locales, we have to do multiple queries

<img width="1272" alt="screen shot 2018-06-20 at 6 23 24 pm" src="https://user-images.githubusercontent.com/11751745/41704143-aa89d4ba-755f-11e8-811f-e6d2304dd4c6.png">

After: Now we can find for multiple locales in 1 query

<img width="1334" alt="screen shot 2018-06-20 at 6 23 46 pm" src="https://user-images.githubusercontent.com/11751745/41704127-a2b342d0-755f-11e8-8eb4-fd7a4c241bf2.png">
